### PR TITLE
Improve term / passage search UX

### DIFF
--- a/src/utilities/ScriptureRef.ts
+++ b/src/utilities/ScriptureRef.ts
@@ -77,6 +77,8 @@ export type ScriptureReference = {
 
  export function parseScriptureReference(input: string): ScriptureReference {
     // Normalize the input string
+    // TODO: Reconsider space stripping for a more fully featured
+    // reference parser; see what other extensions have done
     const normalizedInput = input.replace(/\s+/g, '').toUpperCase();
 
     // Updated regex to match book, chapters, and verses
@@ -90,7 +92,7 @@ export type ScriptureReference = {
     const [, bookPrefix, bookName, startChapter, startVerse, endChapterOrVerse, endVerse] = match;
 
     // Normalize book name for comparison
-    const fullBookName = `${bookPrefix || ''}${bookName}`.toUpperCase();
+    const fullBookName = `${bookPrefix || ''}${bookName}`.toUpperCase().trim();
 
     // Determine the book code
     let bookCode = '';
@@ -101,6 +103,10 @@ export type ScriptureReference = {
     }
     }
   
+    if (!bookCode) {
+      bookCode = fullBookName in bookCodes ? fullBookName : '';
+    }
+
     // Parse numbers
     const startChap = parseInt(startChapter) || 0;
     let endChap = startChap;

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -29,10 +29,18 @@ function App() {
     const { name, value } = target;
 
     if (name === 'searchTerm') {
-      setSearchTerm(value.trim());
+      setSearchTerm(value);
     } else if (name === 'passage') {
-      setPassage(value.trim());
+      setPassage(value);
     }
+  };
+
+  const handleKeyDown = (e: any) => {
+    if (e.key !== 'Enter')  {
+      return;
+    }
+    const target = e.target as HTMLInputElement;
+    const { name, value } = target;
     vscode.postMessage({ command: `search-${name}`, data: value });
   };
 
@@ -154,6 +162,7 @@ function App() {
               placeholder="Bible Passage..."
               value={passage}
               onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
               name="passage"
             />
             <input
@@ -161,6 +170,7 @@ function App() {
               placeholder="Search..."
               value={searchTerm}
               onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
               name="searchTerm"
             />
           </header>


### PR DESCRIPTION
Closes #6.

Branched from #5  (which should be merged first).

## Notes for code review
- Removing `trim()` allows for `TIT 1` and `Sea of`, which were noted as not being possible on #6.
  -  <img width="328" alt="image" src="https://github.com/user-attachments/assets/2c688ebb-b1ee-45dd-b787-007d1da6756b">
  - <img width="328" alt="image" src="https://github.com/user-attachments/assets/0c1ec406-7fc3-4bfb-8c05-9c47c67d49b9">
  - <img width="328" alt="image" src="https://github.com/user-attachments/assets/7b83c690-92cb-48ce-8efa-6849a89be66d">
- Rather than sending each keystroke to the Aquifer API, I've waited for an `Enter` key event
- I added an additional check in ScriptureRef.ts (https://github.com/genesis-ai-dev/aquifer-search-tool/blob/0d8a7884141662c3babf65ee0841590e584da163/src/utilities/ScriptureRef.ts#L106) that better supports direct passing of USFM book names (e.g. `JHN` vs the options in https://github.com/genesis-ai-dev/aquifer-search-tool/blob/0d8a7884141662c3babf65ee0841590e584da163/src/utilities/ScriptureRef.ts#L52).

## Questions 🤔
  - [ ] **Are there other shared utility / library code being used in other Codex extensions for parsing user-provided scripture references**?  If not, should I create one?  It seems like it'd be useful for some of the other extensions I'm hoping to build out this summer.
